### PR TITLE
Add ability to hit PodcastIndex to search and pull episodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,11 @@ Before running the application, ensure you have the following installed on your 
     # Cloud ASR/Diarization Provider (e.g., AssemblyAI)
     ASSEMBLYAI_API_KEY=<YOUR_ASSEMBLYAI_API_KEY>
 
+    # PodcastIndex
+    PODCAST_INDEX_API_KEY=<YOuR_PODCASTINDEX_API_KEY>
+    PODCAST_INDEX_API_SECRET=your_podcastindex_secrEt
+
+
     # Define upload/output directories (optional, defaults are within backend/)
     # UPLOAD_DIR=./uploads
     # OUTPUT_DIR=./output

--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ Before running the application, ensure you have the following installed on your 
     ASSEMBLYAI_API_KEY=<YOUR_ASSEMBLYAI_API_KEY>
 
     # PodcastIndex
-    PODCAST_INDEX_API_KEY=<YOuR_PODCASTINDEX_API_KEY>
-    PODCAST_INDEX_API_SECRET=your_podcastindex_secrEt
+    PODCAST_INDEX_API_KEY=<YOUR_PODCASTINDEX_API_KEY>
+    PODCAST_INDEX_API_SECRET=<YOUR_PODCASTINDEX_API_SECRET>
 
 
     # Define upload/output directories (optional, defaults are within backend/)

--- a/backend/index.ts
+++ b/backend/index.ts
@@ -368,7 +368,7 @@ const serverOptions: ServeOptions = {
             return handleStatus(req, pathSegments[2]); // pathSegments[2] is the job_id
         }
 
-        if (pathSegments[0] === 'api' && pathSegments[1] === 'adjust' && pathSegments[2] && req.method === 'POST') {i
+        if (pathSegments[0] === 'api' && pathSegments[1] === 'adjust' && pathSegments[2] && req.method === 'POST') {
             return handleAdjust(req, pathSegments[2]);
         }
 

--- a/backend/index.ts
+++ b/backend/index.ts
@@ -3,7 +3,9 @@ import Redis from 'ioredis';
 import { v4 as uuidv4 } from 'uuid';
 import path from 'node:path';
 import fs from 'node:fs'; // Import the fs module
+import { handlePodcastSearch, handlePodcastEpisodes } from './routes/podcasts';
 import { type ServeOptions } from 'bun'; // Import ServeOptions type
+
 
 console.log('Starting backend server...');
 
@@ -323,8 +325,8 @@ async function handleDownload(req: Request, jobId: string): Promise<Response> {
 // --- Bun HTTP Server --- //
 const serverOptions: ServeOptions = {
     port: API_PORT,
-    // Set maximum request body size (e.g., 500 MiB)
-    maxRequestBodySize: 500 * 1024 * 1024, // 500 MiB in bytes
+    maxRequestBodySize: 500 * 1024 * 1024,
+    
     async fetch(req: Request): Promise<Response> {
         const url = new URL(req.url);
         const pathSegments = url.pathname.split('/').filter(Boolean); // e.g., ['api', 'upload']
@@ -344,6 +346,15 @@ const serverOptions: ServeOptions = {
             });
         }
 
+	if (pathSegments[0] === 'api' && pathSegments[1] === 'podcasts') {
+	  if (pathSegments[2] === 'search' && req.method === 'GET') {
+	    return handlePodcastSearch(req);
+	  }	
+	  if (pathSegments[2] === 'episodes' && req.method === 'GET') {
+	    return handlePodcastEpisodes(req);
+	  }
+	}
+
         // Basic Routing
         if (url.pathname === '/' && req.method === 'GET') {
             return jsonResponse({ status: 'ok', timestamp: Date.now() });
@@ -357,7 +368,7 @@ const serverOptions: ServeOptions = {
             return handleStatus(req, pathSegments[2]); // pathSegments[2] is the job_id
         }
 
-        if (pathSegments[0] === 'api' && pathSegments[1] === 'adjust' && pathSegments[2] && req.method === 'POST') {
+        if (pathSegments[0] === 'api' && pathSegments[1] === 'adjust' && pathSegments[2] && req.method === 'POST') {i
             return handleAdjust(req, pathSegments[2]);
         }
 
@@ -368,6 +379,7 @@ const serverOptions: ServeOptions = {
         // Default Not Found
         return errorResponse('Not Found', 404);
     },
+
     error(error: Error): Response {
         console.error("Unhandled server error:", error);
         return errorResponse('Internal Server Error', 500);

--- a/backend/routes/podcasts.ts
+++ b/backend/routes/podcasts.ts
@@ -1,0 +1,110 @@
+// routes/podcasts.ts
+
+const API_BASE = 'https://api.podcastindex.org/api/1.0';
+const API_KEY = process.env.PODCAST_INDEX_API_KEY!;
+const API_SECRET = process.env.PODCAST_INDEX_API_SECRET!;
+
+async function getAuthHeaders(): Promise<Record<string, string>> {
+  if (!API_KEY || !API_SECRET) {
+    console.error('[AuthHeaders] Missing API_KEY or API_SECRET', { API_KEY: !!API_KEY, API_SECRET: !!API_SECRET });
+    throw new Error('PodcastIndex API credentials are not set');
+  }
+  const ts = Math.floor(Date.now() / 1000).toString();
+  console.log('[AuthHeaders] Timestamp:', ts);
+  const encoder = new TextEncoder();
+  const data = encoder.encode(API_KEY + API_SECRET + ts);
+  const hashBuffer = await crypto.subtle.digest('SHA-1', data);
+  const signature = Array.from(new Uint8Array(hashBuffer))
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('');
+  console.log('[AuthHeaders] Signature:', signature);
+  return {
+    'User-Agent':    'PodPace/1.0',
+    'X-Auth-Key':    API_KEY,
+    'X-Auth-Date':   ts,
+    'Authorization': signature,
+  };
+}
+
+/**
+ * Handles GET /api/podcasts/search?q=TERM
+ */
+export async function handlePodcastSearch(req: Request): Promise<Response> {
+  console.log('[PodcastSearch] Request:', req.method, req.url);
+  const url = new URL(req.url);
+  const q   = (url.searchParams.get('q') || '').trim();
+  if (!q) {
+    console.warn('[PodcastSearch] Missing query parameter q');
+    return new Response(JSON.stringify({ error: 'Missing "q" parameter.' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' }
+    });
+  }
+  console.log('[PodcastSearch] Query:', q);
+
+  try {
+    const apiUrl = `${API_BASE}/search/byterm?${new URLSearchParams({ q })}`;
+    console.log('[PodcastSearch] Calling API:', apiUrl);
+    const headers = await getAuthHeaders();
+    const resp = await fetch(apiUrl, { headers });
+    console.log('[PodcastSearch] API status:', resp.status);
+    if (!resp.ok) throw new Error(`PodcastIndex search failed: ${resp.status}`);
+    const data = await resp.json();
+    const feeds = (data.feeds || []).map((f: any) => ({
+      feedId:      f.id,
+      title:       f.title,
+      description: f.description,
+      image:       f.image,
+    }));
+    console.log('[PodcastSearch] Feeds count:', feeds.length);
+    return new Response(JSON.stringify({ feeds }), { headers: { 'Content-Type': 'application/json' } });
+  } catch (err: any) {
+    console.error('[PodcastSearch] Error:', err);
+    return new Response(JSON.stringify({ error: 'Podcast search error.' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' }
+    });
+  }
+}
+
+/**
+ * Handles GET /api/podcasts/episodes?feedId=ID
+ */
+export async function handlePodcastEpisodes(req: Request): Promise<Response> {
+  console.log('[PodcastEpisodes] Request:', req.method, req.url);
+  const url    = new URL(req.url);
+  const feedId = (url.searchParams.get('feedId') || '').trim();
+  if (!feedId) {
+    console.warn('[PodcastEpisodes] Missing query parameter feedId');
+    return new Response(JSON.stringify({ error: 'Missing "feedId" parameter.' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' }
+    });
+  }
+  console.log('[PodcastEpisodes] Feed ID:', feedId);
+
+  try {
+    const apiUrl = `${API_BASE}/episodes/byfeedid?${new URLSearchParams({ id: feedId })}`;
+    console.log('[PodcastEpisodes] Calling API:', apiUrl);
+    const headers = await getAuthHeaders();
+    const resp    = await fetch(apiUrl, { headers });
+    console.log('[PodcastEpisodes] API status:', resp.status);
+    if (!resp.ok) throw new Error(`PodcastIndex episodes failed: ${resp.status}`);
+    const data = await resp.json();
+    const episodes = (data.items || []).map((i: any) => ({
+      episodeId: i.id,
+      title:     i.title,
+      audioUrl:  i.enclosureUrl,
+      pubDate:   i.pubDate,
+      duration:  i.duration,
+    }));
+    console.log('[PodcastEpisodes] Episodes count:', episodes.length);
+    return new Response(JSON.stringify({ episodes }), { headers: { 'Content-Type': 'application/json' } });
+  } catch (err: any) {
+    console.error('[PodcastEpisodes] Error:', err);
+    return new Response(JSON.stringify({ error: 'Episodes fetch error.' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' }
+    });
+  }
+}


### PR DESCRIPTION
Integrated https://podcastindex-org.github.io/docs-api

We can now do keyword searches ("huberman"), find all feeds that hit that keyword, and then pull down all episodes in a specific feed.

There is no frontend code for this (yet), but figured the backend is complete enough that we could create a PR.

Example CURL for Huberman, once the local server is up and running:
```

feedId=$(curl -s -G "http://localhost:3000/api/podcasts/search" \
  --data-urlencode "q=huberman" \
  -H "Accept: application/json" \
  | jq -r '.feeds[0].feedId') && \
curl -G "http://localhost:3000/api/podcasts/episodes" \
  --data-urlencode "feedId=$feedId" \
  -H "Accept: application/json"
```

Here's a shortened output:
```
{"episodes":[{"episodeId":36190119994,"title":"Essentials: How to Build Endurance","audioUrl":"https://www.podtrac.
com/pts/redirect.mp3/traffic.megaphone.fm/SCIM1120276865.mp3?updated=1744865048","duration":2648},{"episodeId":3606
6397027,"title":"How to Improve Your Vitality & Heal From Disease | Dr. Mark Hyman","audioUrl":"https://www.podtrac
.com/pts/redirect.mp3/traffic.megaphone.fm/SCIM9845833582.mp3?updated=1744604658","duration":9740},

```

And here's the backend logging:

```
Request: GET /api/podcasts/search
[PodcastSearch] Request: GET http://localhost:3000/api/podcasts/search?q=huberman
[PodcastSearch] Query: huberman
[PodcastSearch] Calling API: https://api.podcastindex.org/api/1.0/search/byterm?q=huberman
[PodcastSearch] API status: 200
[PodcastSearch] Feeds count: 14

Request: GET /api/podcasts/episodes
[PodcastEpisodes] Request: GET http://localhost:3000/api/podcasts/episodes?feedId=1365758
[PodcastEpisodes] Feed ID: 1365758
[PodcastEpisodes] Calling API: https://api.podcastindex.org/api/1.0/episodes/byfeedid?id=1365758
[PodcastEpisodes] API status: 200
[PodcastEpisodes] Episodes count: 40
```



Happy to keep this on hold until the frontend code is running, if you'd like!