### PR TITLE
Add frontend for searching podcast feeds, selecting episodes, and kicking into transcription

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -43,7 +43,7 @@
 
 button.active-tab {
  background: var(--accent);
- color: #ffff;
+ color: #fff;
 }
 
 @media (max-width: 600px) {
@@ -51,3 +51,33 @@ button.active-tab {
     flex: 1 1 50%;
   }
 }
+
+.mode-toggle {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.show-card:hover {
+  transform: translateY(-3px);
+  transition: transform 0.12s ease;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.4);
+}
+
+/* Simple spinner overlay */
+.spinner-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0,0,0,0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  font-size: 1.2rem;
+  z-index: 999;
+}
+

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -40,3 +40,14 @@
 .read-the-docs {
   color: #888;
 }
+
+button.active-tab {
+ background: var(--accent);
+ color: #ffff;
+}
+
+@media (max-width: 600px) {
+  .mode-toggle button {
+    flex: 1 1 50%;
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,9 +7,11 @@ import SpeakerAdjuster from './components/SpeakerAdjuster'
 import DownloadArea from './components/DownloadArea'
 import ErrorMessage from './components/ErrorMessage'
 import SearchBar from './components/SearchBar'
+import FeedList from './components/FeedList'
+import EpisodeList from './components/EpisodeList'
 
 // Import frontend interfaces from the correct relative path
-import type { SpeakerWPM, JobStatus, PodcastFeed } from './interfaces'
+import type { SpeakerWPM, JobStatus, PodcastFeed, PodcastEpisode } from './interfaces'
 
 
 
@@ -28,6 +30,9 @@ function App() {
   const [outputFilename, setOutputFilename] = useState<string | null>(null); // To construct download URL
   const [mode, setMode] = useState<'UPLOAD' | 'SEARCH'>('UPLOAD'); // just tossing this in for now incase we want to keep the upload workflow
   const [feeds, setFeeds] = useState<PodcastFeed[]>([]);
+  const [selectedFeed, setSelectedFeed] = useState<PodcastFeed | null>(null);
+  const [episodes, setEpisodes] = useState<PodcastEpisode[]>([]);
+  const [selectedEpisode, setSelectedEpisode] = useState<PodcastEpisode|null>(null);
 
   // --- Handler Functions (to be passed to components) ---
 
@@ -88,6 +93,7 @@ function App() {
   const handleReset = () => {
     setJobId(null);
     setJobStatus('IDLE');
+    setSelectedEpisode(null);
     setSpeakerData([]);
     setError(null);
     setIsLoading(false);
@@ -100,8 +106,18 @@ function App() {
         setIsLoading(true);
         const apiUrl = '/api';
         const res = await fetch (`${apiUrl}/podcasts/search?q=${encodeURIComponent(query)}`);
+        if (!res.ok) throw new Error(`Search failed (${res.status})`);
         const data = await res.json();
-        setFeeds(data.feeds);
+
+        // remapping feedId -> id for frontend and consistency. or, should we just use feedId and update FE logic...?
+        const feeds: PodcastFeed[] = data.feeds.map((f: any) => ({
+            id: f.feedId || f.id,
+            title: f.title,
+            description: f.description,
+            image: f.image,
+        }));
+        console.log('[handlePodcastSearch] Mapped feeds:', feeds);
+        setFeeds(feeds);
     } catch (e: any) {
         setError(e.message);
     } finally {
@@ -109,87 +125,146 @@ function App() {
     }
   };
 
-  return (
-    <div className="App">
-      <h1>PodPace - Speech Normalizer</h1>
-      
-      <div>
-        <button
-            onClick={() => setMode('UPLOAD')}
-            className={mode === 'UPLOAD' ? 'active-tab' : ''}
-        >
-            Upload Audio
-        </button>
+  const handleFeedSelect = async (feed: PodcastFeed) => {
+    try {
+        setSelectedFeed(feed);
+        setError(null);
+        setIsLoading(true);
+        const apiUrl = '/api';
+        const res = await fetch(`${apiUrl}/podcasts/episodes?feedId=${encodeURIComponent(feed.id)}`);
+        if (!res.ok) throw new Error(`Episode load failed (${res.status})`);
+        const data = await res.json();
+        console.log('[handleFeedSelect] got episodes', data.episodes);
+        setEpisodes(data.episodes);
+    } catch (e: any) {
+        setError(e.message);
+    } finally {
+        setIsLoading(false);
+    }
+  };
 
-        <button
-            onClick={() => setMode('SEARCH')}
-            className={mode === 'SEARCH' ? 'active-tab' : ''}
-        >
-            Search Podcasts
-        </button>
-      </div>
+  const handleEpisodeSelect = async (ep: PodcastEpisode) => {
+    try {
+        setError(null);
+        setIsLoading(true);
+        setSelectedEpisode(ep);
+        const audioResp = await fetch(ep.audioUrl);
+        if (!audioResp.ok) throw new Error(`Failed to download audio (${audioResp.status})`);
+        const blob = await audioResp.blob();
 
-      <ErrorMessage message={error} />
+        const form = new FormData();
+        const safeTitle = ep.title.replace(/[^a-z0-9]/gi, '_');
+        form.append('audioFile', blob, `${safeTitle}.mp3`);
 
+        const apiUrl = '/api';
+        const uploadRes = await fetch(`${apiUrl}/upload`, {
+            method: 'POST',
+            body: form,
+        });
+        const result = await uploadRes.json();
+        handleUploadSuccess(result.job_id);
+        setSelectedFeed(null);
+        setFeeds([]);
+        setEpisodes([]);
+        setMode('UPLOAD');
+    } catch (e: any) {
+        setError(e.message);
+    } finally {
+        setIsLoading(false);
+    }
+  }
 
-      
-      {mode === 'UPLOAD' && jobStatus === 'IDLE' && (
-        // Render FileUpload component when idle
-        <FileUpload
-          onUploadSuccess={handleUploadSuccess}
-          onUploadError={handleUploadError}
-          setIsLoading={setIsLoading}
-        />
-      )}
+    return (
+      <div className="App">
+        <h1>PodPace – Speech Normalizer</h1>
+        <ErrorMessage message={error} />
+        {isLoading && jobStatus !== 'FAILED' && <p>Uploading…</p>}
 
-      {mode === 'SEARCH' && (
-        <div>
-        <SearchBar onSearch={handlePodcastSearch}/>
-        {feeds.length > 0 && (
-            <pre style={{ textAlign: 'left', whitespace: 'pre-wrap' }}>
-                {JSON.stringify(feeds, null, 2)}
-            </pre>
+        { /* === NOTHING IN FLIGHT: show Upload vs Search === */ }
+        {jobStatus === 'IDLE' ? (
+          <>
+            <div className="mode-toggle">
+              <button
+                className={mode === 'UPLOAD' ? 'active-tab' : ''}
+                onClick={() => setMode('UPLOAD')}
+              >
+                Upload Audio
+              </button>
+              <button
+                className={mode === 'SEARCH' ? 'active-tab' : ''}
+                onClick={() => setMode('SEARCH')}
+              >
+                Search Podcasts
+              </button>
+            </div>
+
+            {mode === 'UPLOAD' && (
+              <FileUpload
+                onUploadSuccess={handleUploadSuccess}
+                onUploadError={handleUploadError}
+                setIsLoading={setIsLoading}
+              />
+            )}
+
+            {mode === 'SEARCH' && (
+              <>
+                <SearchBar onSearch={handlePodcastSearch} />
+                <FeedList feeds={feeds} onSelect={handleFeedSelect} />
+                {selectedFeed && (
+                  <>
+                    <h3>Episodes for “{selectedFeed.title}”</h3>
+                    <EpisodeList
+                      episodes={episodes}
+                      onSelectEpisode={handleEpisodeSelect}
+                    />
+                  </>
+                )}
+              </>
+            )}
+          </>
+        ) : (
+          <>
+            {/* Show the selected episode title */}
+            {selectedEpisode && (
+              <h3 style={{ margin: '1rem 0' }}>
+                Processing episode: “{selectedEpisode.title}”
+              </h3>
+            )}
+
+            <JobProgress
+              jobId={jobId!}
+              currentStatus={jobStatus}
+              onStatusUpdate={handleStatusUpdate}
+            />
+
+            {jobStatus === 'READY_FOR_INPUT' && speakerData.length > 0 && (
+              <SpeakerAdjuster
+                jobId={jobId!}
+                speakerData={speakerData}
+                onSubmit={handleAdjustmentSubmit}
+                onError={handleUploadError}
+              />
+            )}
+
+            {/* Final download area with completed title */}
+            {jobStatus === 'COMPLETE' && jobId && outputFilename && (
+              <>
+                {selectedEpisode && (
+                  <h3 style={{ margin: '1rem 0' }}>
+                    Finished: “{selectedEpisode.title}”
+                  </h3>
+                )}
+                <DownloadArea jobId={jobId} outputFilename={outputFilename} />
+              </>
+            )}
+
+            {(jobStatus === 'FAILED' || jobStatus === 'COMPLETE') && (
+              <button onClick={handleReset}>Start New Job</button>
+            )}
+          </>
         )}
-        </div>
-      )}
-
-      {isLoading && jobStatus !== 'FAILED' && <p>Uploading...</p>}
-
-      {jobId &&
-        !['IDLE', 'FAILED', 'READY_FOR_INPUT', 'COMPLETE'].includes(jobStatus) && (
-          // Show JobProgress component while processing
-          <JobProgress
-            jobId={jobId}
-            currentStatus={jobStatus}
-            onStatusUpdate={handleStatusUpdate}
-          />
-      )}
-
-      {jobStatus === 'READY_FOR_INPUT' && speakerData.length > 0 && (
-        // Render SpeakerAdjuster component when ready for input
-        <SpeakerAdjuster
-            jobId={jobId!}
-            speakerData={speakerData}
-            onSubmit={handleAdjustmentSubmit}
-            onError={handleUploadError}
-        />
-      )}
-
-      {jobStatus === 'COMPLETE' && jobId && outputFilename && (
-        // Render DownloadArea component when complete
-        <DownloadArea
-            jobId={jobId}
-            outputFilename={outputFilename}
-        />
-      )}
-
-      {/* Optionally show a reset button if failed or complete */}
-      {(jobStatus === 'FAILED' || jobStatus === 'COMPLETE') && (
-          <button onClick={handleReset}>Start New Job</button>
-      )}
-
-    </div>
-  );
+      </div>
+    );
 }
 
 export default App

--- a/frontend/src/components/EpisodeList.tsx
+++ b/frontend/src/components/EpisodeList.tsx
@@ -1,0 +1,63 @@
+import { PodcastEpisode } from './interfaces';
+
+interface Props {
+    episodes: PodcastEpisode[];
+    onSelectEpisode: (ep: PodcastEpisode) => void;
+}
+
+const EpisodeList: React.FC<Props> = ({ episodes, onSelectEpisode }) => {
+    if (!episodes.length) {
+        return <p style={{ marginTop: '1rem' }}>No episodes available.</p>;
+    }
+
+    return (
+        <div
+            style = {{
+                maxHeight: '400px',
+                overflow: 'auto',
+                marginTop: '1rem',
+                padding: '1rem',
+                border: '1px solid var(--border)',
+                borderRadius: '6px',
+                background: 'var(--bg-secondary)',
+            }}
+        >
+            {episodes.map(ep => (
+                <div
+                    key={ep.id}
+                    style = {{
+                        display: 'flex',
+                        justifyContent: 'space-between',
+                        alignItems: 'center',
+                        padding: '0.5rem 0',
+                        borderBottom: '1px solid var(--border)',
+                    }}
+                >
+                    <div>
+                        <div style={{ fontWeight: 500 }}>
+                            {ep.title}
+                        </div>
+                        <div style={{ fontSize: '0.85rem', color: 'var(--text-muted)' }}>
+                            {new Date(ep.datePublished).toLocaleDateString()}    
+                        </div>
+                    </div>
+                    <button
+                        onClick={() => onSelectEpisode(ep)}
+                        style={{
+                            padding: '0.4rem 0.8rem',
+                            borderRadius: '4px',
+                            border: 'none',
+                            background: 'var(--accent)',
+                            color: '#fff',
+                            cursor: 'pointer',
+                        }}
+                    >
+                        Select
+                    </button>
+                </div>
+            ))}
+        </div>
+    );
+};
+
+export default EpisodeList;

--- a/frontend/src/components/FeedList.tsx
+++ b/frontend/src/components/FeedList.tsx
@@ -1,0 +1,63 @@
+import { PodcastFeed } from './interfaces';
+
+interface Props {
+    feeds: PodcastFeed[];
+    onSelect: (feed: PodcastFeed) => void;
+}
+
+const truncate = (txt: string, len = 120) =>
+    txt.length > len ? txt.slice(0, len) + '...' : txt;
+
+const FeedList: React.FC<Props> = ({ feeds, onSelect }) => {
+    if (!feeds.length) return null;
+
+    return (
+        <div
+            style = {{
+                display: 'grid',
+                gap: '1rem',
+                marginTop: '1.5rem',
+                gridTemplateColumns: 'repeat(auto-fill,minmax(260px, 1fr))',
+            }}
+        >
+            {feeds.map((feed) => (
+                <div
+                    key={feed.id}
+                    onClick={() => {
+                        console.log('[FeedList] Feed selected:', feed);
+                        onSelect(feed);
+                    }}
+                    className="show-card"
+                    style={{
+                        cursor: 'pointer',
+                        background: 'var(--bg-secondary, #1e1e1e)',
+                        border: '1px solid var(--border, #333)',
+                        borderRadius: '6px',
+                        padding: '1rem',
+                        display: 'flex',
+                        flexDirection: 'column',
+                    }}
+                >
+                    <img
+                        src={feed.image}
+                        alt={feed.title}
+                        style={{
+                            width: '100%',
+                            height: '140px',
+                            objectFit: 'cover',
+                            borderRadius: '4px',
+                            marginBottom: '0.75rem',
+                        }}
+                        loading="lazy"
+                    />
+                    <h4 style={{ margin: 0, marginBottom: '0.5rem' }}>{feed.title}</h4>
+                    <p style={{ fontSize: '0,85rem', lineHeight: '1.4' }}>
+                        {truncate(feed.description)}
+                    </p>
+                </div>
+            ))}
+        </div>
+    );
+};
+
+export default FeedList;

--- a/frontend/src/components/SearchBar.tsx
+++ b/frontend/src/components/SearchBar.tsx
@@ -1,0 +1,43 @@
+import { useState, KeyboardEvent } from 'react';
+
+interface Props {
+    onSearch: (query: string) => void;
+}
+
+const SearchBar: React.FC<Props> = ({ onSearch }) => {
+    const [q, setQ] = useState('');
+
+    const search = () => {
+        if (q.trim()) onSearch(q.trim());
+    };
+
+    const handleKey = (e: KeyboardEvent<HTMLInputElement>) => {
+        if (e.key === 'Enter') search();
+    };
+
+    return (
+        <div style ={{ textAlign: 'center', marginTop: '1rem' }}>
+            <input
+                type="text"
+                placeholder="Search..."
+                value={q}
+                onChange={(e) => setQ(e.target.value)}
+                onKeyDown={handleKey}
+                style={{
+                    padding: '0.6rem 0.8rem',
+                    minWidth: '260px',
+                    border: '1px solid var(--border)',
+                    borderRadius: '4px',
+                    marginRight: '0.5rem',
+                    background: 'var(--bg)',
+                    color: 'var(--text)',
+                }}
+            />        
+            <button onClick={search} style={{ padding: '0.6rem 1.2rem' }}>
+                Smash it
+            </button>
+        </div>
+    );
+};
+
+export default SearchBar;

--- a/frontend/src/interfaces.ts
+++ b/frontend/src/interfaces.ts
@@ -27,3 +27,17 @@ export type JobStatus =
   | 'PROCESSING_RECONSTRUCTION'
   | 'COMPLETE'
   | 'FAILED';
+
+export interface PodcastFeed {
+    id: string;
+    title: string;
+    description: string;
+    image: string;
+}
+
+export interface PodcastEpisode {
+    id: string;
+    title: string;
+    datePublished: string;
+    audioUrl: string;
+}


### PR DESCRIPTION
A quick and dirty way to search for podcasts, select an episode from that podcast, and go back through existing workflow of upload to Assembly, change WPM, and download mp3 file.

A ton of UX / UI work is still needed to make this okay to use  (e.g. the dates are erroring out, there's some duplication when showing titles on the last screen, and the flow of selecting a podcast is not very pretty and sorta confusing), but it is functional lol.

Also, the styling in my components are in-line, which is obviously not ideal. Lots of refactoring will be useful, but didn't want to mess too much with other things until I got this basic functionality merged in.

## 1. Search bar and podcast results
![image](https://github.com/user-attachments/assets/dc929fa8-be44-4e38-abb6-d0ccc7463f84)

## 2. Episodes after clicking on one of the tiles
![image](https://github.com/user-attachments/assets/1107a216-fb9c-496f-96f6-4932044b6c1d)

## 3. After clicking "Select" beside one of the episodes, and waiting for it to fully upload
![image](https://github.com/user-attachments/assets/19782d98-ef41-477e-9087-daef81253d80)

## 4. After hitting download (this is a different episode from the screenshots)
![image](https://github.com/user-attachments/assets/7abc1265-2add-4ab9-8bde-7766871c6f85)

